### PR TITLE
Add check for existence of edge in scaffold graph (overlap stage)

### DIFF
--- a/bin/ntlink_overlap_sequences.py
+++ b/bin/ntlink_overlap_sequences.py
@@ -360,7 +360,7 @@ def merge_overlapping_pathfile(args, gap_re, graph, mxs, mxs_info, scaffolds):
                 if not gap_match:
                     continue
                 if int(gap_match.group(1)) <= args.g + 1 and \
-                        graph.es()[ntlink_utils.edge_index(graph, source, target)]["d"] < 0:
+                        ntlink_utils.has_estimated_overlap(graph, source, target):
                     cuts_found = merge_overlapping(mxs, mxs_info, source, target, scaffolds, args,
                                       graph.es()[ntlink_utils.edge_index(graph, source, target)]["d"])
                     if cuts_found:

--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -48,6 +48,14 @@ def has_vertex(graph, name):
         return False
     return True
 
+def has_edge(g, source, target):
+    "Returns True if graph has edge, else False"
+    try:
+        edge_index(g, source, target)
+    except ig.InternalError:
+        return False
+    return True
+
 def read_fasta_file(filename):
     "Read a fasta file into memory. Returns dictionary of scafID -> Scaffold"
     print(datetime.datetime.today(), ": Reading fasta file", filename, file=sys.stdout)
@@ -76,7 +84,6 @@ def reverse_scaf_ori(scaffold):
 def read_scaffold_graph(in_graph_file):
     "Reads in a scaffold graph in dot format"
     print(datetime.datetime.today(), ": Reading scaffold file", in_graph_file, file=sys.stdout)
-
 
     graph = ig.Graph(directed=True)
 
@@ -136,7 +143,8 @@ def find_valid_mx_regions(args, gap_re, graph, scaffolds):
                 gap_match = re.search(gap_re, gap)
                 if not gap_match:
                     continue
-                if int(gap_match.group(1)) <= args.g + 1 and graph.es()[edge_index(graph, source, target)]["d"] < 0:
+                if int(gap_match.group(1)) <= args.g + 1 and has_edge(graph, source, target) and \
+                        graph.es()[edge_index(graph, source, target)]["d"] < 0:
                     gap = graph.es()[edge_index(graph, source, target)]["d"]
                     source_start, source_end = find_valid_mx_region(source_noori, source[-1],
                                                                     scaffolds, gap, args)

--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -48,13 +48,14 @@ def has_vertex(graph, name):
         return False
     return True
 
-def has_edge(g, source, target):
-    "Returns True if graph has edge, else False"
+def has_estimated_overlap(graph, source, target):
+    "Returns True if the edge has an estimated overlap, else False"
     try:
-        edge_index(g, source, target)
+        overlap = graph.es()[edge_index(graph, source, target)]["d"]
+        return overlap < 0
     except ig.InternalError:
         return False
-    return True
+
 
 def read_fasta_file(filename):
     "Read a fasta file into memory. Returns dictionary of scafID -> Scaffold"
@@ -143,8 +144,7 @@ def find_valid_mx_regions(args, gap_re, graph, scaffolds):
                 gap_match = re.search(gap_re, gap)
                 if not gap_match:
                     continue
-                if int(gap_match.group(1)) <= args.g + 1 and has_edge(graph, source, target) and \
-                        graph.es()[edge_index(graph, source, target)]["d"] < 0:
+                if int(gap_match.group(1)) <= args.g + 1 and has_estimated_overlap(graph, source, target):
                     gap = graph.es()[edge_index(graph, source, target)]["d"]
                     source_start, source_end = find_valid_mx_region(source_noori, source[-1],
                                                                     scaffolds, gap, args)


### PR DESCRIPTION
* In rare cases, two contigs may be adjacent in the path file, but not have a direct edge between them in the scaffold graph
  * To avoid ntLink failing in such cases, added logic to just skip checking for overlaps between the contigs in such cases