### PR TITLE
Fixes to clean-up of path files in ntLink

### DIFF
--- a/ntLink
+++ b/ntLink
@@ -113,14 +113,13 @@ help:
 
 scaffold: check_params \
 	ntLink_graph \
-	abyss_scaffold \
-	clean
+	abyss_scaffold
 
 LIST = $(shell seq $(n) $(max_n))
 LIST_n = $(addprefix .n, $(LIST))
 path_targets = $(addsuffix .abyss-scaffold.path, $(addprefix $(prefix), $(LIST_n)))
 ntLink_graph: $(target).k$(k).w$(w).tsv \
-	$(path_targets)
+	$(prefix).n$(n).scaffold.dot
 
 abyss_scaffold: ntLink_graph \
 	$(target).k$(k).w$(w).z$(z).stitch.abyss-scaffold.fa \
@@ -173,6 +172,7 @@ else
 	$(ntLink_time) $(ntlink_path)/bin/ntlink_stitch_paths.py --min_n $(n) --max_n $(max_n)  -p out \
 	-g $(prefix).n$(n).scaffold.dot $^ -o $@
 endif
+	rm -f $(prefix).n*.abyss-scaffold.path $(prefix).n*.abyss-scaffold.path.sterr
 
 $(target).k$(small_k).w$(small_w).tsv: $(target)
 	$(ntLink_time) $(ntlink_path)/src/indexlr --long --pos -k $(small_k) -w $(small_w) -t $(t) $< > $@
@@ -192,6 +192,5 @@ $(target).k$(k).w$(w).z$(z).stitch.abyss-scaffold.fa: $(target) $(prefix).stitch
 	$(ntLink_time) MergeContigs -k2 $< $(prefix).stitch.path > $@
 endif
 
-
-clean: $(target).k$(k).w$(w).z$(z).stitch.abyss-scaffold.fa
-	rm $(prefix).n*.abyss-scaffold.path $(prefix).n*.abyss-scaffold.path.sterr
+clean: abyss_scaffold
+	rm -f $(prefix).n*.abyss-scaffold.path $(prefix).n*.abyss-scaffold.path.sterr


### PR DESCRIPTION
* Fix targets to avoid error when execute same ntLink command again after a complete or partial ntLink run
  * Remove abyss-scaffold intermediate files right after using them, path files do not need to be target for `scaffold`.