### PR TITLE
ntLink output scaffolds naming fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
 
 - job: macOS_default_clang
   pool:
-    vmImage: macOS-10.14
+    vmImage: macOS-latest
   steps:
   - script: make -C src all
     displayName: Compile C++ executables with clang

--- a/bin/ntlink_filter_sequences.py
+++ b/bin/ntlink_filter_sequences.py
@@ -34,7 +34,7 @@ def main():
     gap_re = re.compile(r'^(\d+)N$')
 
     with ntlink_utils.HiddenPrints():
-        graph = ntlink_utils.read_scaffold_graph(args.dot)
+        graph, _ = ntlink_utils.read_scaffold_graph(args.dot)
         scaffolds = ntlink_overlap_sequences.read_fasta_file_trim_prep(args.fasta)
         valid_mx_regions = ntlink_utils.find_valid_mx_regions(args, gap_re, graph, scaffolds)
 

--- a/bin/ntlink_overlap_sequences.py
+++ b/bin/ntlink_overlap_sequences.py
@@ -434,7 +434,7 @@ def main():
     args.outgap = args.outgap + 1 # Accounting for abyss-scaffold incrementing by one in path file
 
     scaffolds = read_fasta_file_trim_prep(args.fasta)
-    graph = ntlink_utils.read_scaffold_graph(args.d)
+    graph, _ = ntlink_utils.read_scaffold_graph(args.d)
 
     valid_mx_positions = ntlink_utils.find_valid_mx_regions(args, gap_re, graph, scaffolds)
 

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -9,6 +9,7 @@ import datetime
 from collections import defaultdict
 from collections import namedtuple
 import itertools
+import re
 import sys
 import numpy as np
 import igraph as ig
@@ -102,13 +103,29 @@ class NtLink():
     "Represents an ntLink graph construction run"
 
     @staticmethod
-    def print_directed_graph(graph, out_prefix):
+    def get_largest_ntlink_scaffold_id(scaffolds):
+        "Detect if any headers adhere to ntLink_\d+ convention, and if so return the largest number"
+        header_re = re.compile(r"^ntLink_(\d+)$")
+        largest_num = None
+
+        for scaffold in scaffolds:
+            header_match = re.search(header_re, scaffold)
+            if header_match:
+                largest_num = int(header_match.group(1)) \
+                    if largest_num is None or int(header_match.group(1)) > largest_num \
+                    else largest_num
+
+        return largest_num
+
+    @staticmethod
+    def print_directed_graph(graph, out_prefix, scaffolds):
         "Prints the directed scaffold graph in dot format"
         out_graph = out_prefix + ".scaffold.dot"
         outfile = open(out_graph, 'w')
         print(datetime.datetime.today(), ": Printing graph", out_graph, sep=" ", file=sys.stdout)
 
         outfile.write("digraph G {\n")
+        outfile.write("graph [scaf_num={}]\n".format(NtLink.get_largest_ntlink_scaffold_id(scaffolds)))
 
         for node in graph.vs():
             node_label = "\"{scaffold}\" [l={length}]\n".\
@@ -493,7 +510,7 @@ class NtLink():
         graph = self.filter_graph_global(graph, int(self.args.n))
 
         # Print out the directed graph
-        self.print_directed_graph(graph, "{0}.n{1}".format(self.args.p, self.args.n))
+        self.print_directed_graph(graph, "{0}.n{1}".format(self.args.p, self.args.n), scaffolds)
 
         print(datetime.datetime.today(), ": DONE!", file=sys.stdout)
 

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -104,8 +104,8 @@ class NtLink():
 
     @staticmethod
     def get_largest_ntlink_scaffold_id(scaffolds):
-        "Detect if any headers adhere to ntLink_\d+ convention, and if so return the largest number"
-        header_re = re.compile(r"^ntLink_(\d+)$")
+        "Detect if any headers adhere to ntLink_{num} convention, and if so return the largest number"
+        header_re = re.compile(r'^ntLink_(\d+)$')
         largest_num = None
 
         for scaffold in scaffolds:

--- a/bin/ntlink_stitch_paths.py
+++ b/bin/ntlink_stitch_paths.py
@@ -393,9 +393,9 @@ class NtLinkPath:
         return best_file
 
     @staticmethod
-    def print_paths(paths, out_filename):
+    def print_paths(paths, out_filename, scaf_num):
         "Print the contig paths"
-        path_id = 0
+        path_id = 0 if scaf_num is None else scaf_num + 1
         with open(out_filename, 'w') as fout:
             for path in paths:
                 path_list = []
@@ -418,13 +418,14 @@ class NtLinkPath:
 
         path_graph = self.read_paths(best_file)
 
+        scaffold_graph, scaf_num = ntlink_utils.read_scaffold_graph(self.args.g)
+
         if self.args.conservative:
             print("Printing paths for optimal N50, no stitching...\n", file=sys.stdout)
             paths = self.find_paths(path_graph)
-            self.print_paths(paths, self.args.o)
+            self.print_paths(paths, self.args.o, scaf_num)
             sys.exit(0)
 
-        scaffold_graph = ntlink_utils.read_scaffold_graph(self.args.g)
 
         self.read_alternate_pathfiles(path_graph, scaffold_graph, best_file)
 
@@ -439,7 +440,7 @@ class NtLinkPath:
 
         paths = self.find_paths(path_graph)
 
-        self.print_paths(paths, self.args.o)
+        self.print_paths(paths, self.args.o, scaf_num)
 
 
 

--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -91,6 +91,9 @@ def read_scaffold_graph(in_graph_file):
     vertices = set()
     edges = defaultdict(dict)  # source -> target -> EdgeInfo
 
+    scaf_num = None
+
+    scaf_num_re = re.compile(r'graph \[scaf_num=(\S+)\]')
     node_re = re.compile(r'\"(\S+[+-])\"\s+\[l\=\d+\]')
     edge_re = re.compile(r'\"(\S+[+-])\"\s+\-\>\s+\"(\S+[+-])\"\s+\[d\=(\-?\d+)\s+e\=\d+\s+n\=(\d+)\]')
 
@@ -112,6 +115,13 @@ def read_scaffold_graph(in_graph_file):
                 source, target, gap_est, num_links = edge_match.group(1), edge_match.group(2), \
                                                      edge_match.group(3), edge_match.group(4)
                 edges[source][target] = (int(gap_est), int(num_links))
+                continue
+            scaf_num_match = re.search(scaf_num_re, line)
+            if scaf_num_match:
+                try:
+                    scaf_num = int(scaf_num_match.group(1))
+                except:
+                    scaf_num = None
             elif line != "}":
                 print("Error! Unexpected line in input dot file:", line)
                 sys.exit(1)
@@ -126,7 +136,7 @@ def read_scaffold_graph(in_graph_file):
     graph.es()["d"] = [edge_attributes[e]['d'] for e in sorted(edge_attributes.keys())]
     graph.es()["n"] = [edge_attributes[e]['n'] for e in sorted(edge_attributes.keys())]
 
-    return graph
+    return graph, scaf_num
 
 def find_valid_mx_regions(args, gap_re, graph, scaffolds):
     "Return a dictionary with scaffold -> [(start, end)], marking the valid overlap positions for minimizers on contigs"

--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -120,7 +120,7 @@ def read_scaffold_graph(in_graph_file):
             if scaf_num_match:
                 try:
                     scaf_num = int(scaf_num_match.group(1))
-                except:
+                except ValueError:
                     scaf_num = None
             elif line != "}":
                 print("Error! Unexpected line in input dot file:", line)


### PR DESCRIPTION
* If any scaffolds in the input assembly file have the pattern "ntLink_\<num\>", this is now detected, and the output ntLink scaffolds headers will start at "ntLink_\<num + 1\>" to avoid any name collisions
* Important if running rounds of ntLink
* Update macOS VM image (previous was deprecated)