### PR TITLE
Release v1.2.0

### DIFF
--- a/bin/ntlink_filter_sequences.py
+++ b/bin/ntlink_filter_sequences.py
@@ -27,7 +27,7 @@ def main():
     parser.add_argument("-k", help="K-mer size (bp)", required=True, type=int)
     parser.add_argument("-f", help="Fudge factor for estimated overlap [0.5]", type=float, default=0.5)
     parser.add_argument("-g", help="Minimum gap size (bp) [20]", required=False, type=int, default=20)
-    parser.add_argument("-v", "--version", action='version', version='ntLink v1.1.3')
+    parser.add_argument("-v", "--version", action='version', version='ntLink v1.2.0')
 
     args = parser.parse_args()
 

--- a/bin/ntlink_overlap_sequences.py
+++ b/bin/ntlink_overlap_sequences.py
@@ -426,7 +426,7 @@ def parse_arguments():
     parser.add_argument("-p", help="Output file prefix [ntlink_merge]", default="ntlink_merge", type=str)
     parser.add_argument("-v", help="Verbose output logging", action="store_true")
     parser.add_argument("--trim_info", help="Verbose log of trimming info", action="store_true")
-    parser.add_argument("--version", action='version', version='ntLink v1.1.3')
+    parser.add_argument("--version", action='version', version='ntLink v1.2.0')
 
     return parser.parse_args()
 

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -434,7 +434,7 @@ class NtLink():
         parser.add_argument("-x", help="Fudge factor allowed between mapping block lengths on read and assembly. "
                                        "Set to 0 to allow mapping block to be up to read length",
                             type=float, default=0)
-        parser.add_argument("-v", "--version", action='version', version='ntLink v1.1.3')
+        parser.add_argument("-v", "--version", action='version', version='ntLink v1.2.0')
         parser.add_argument("--verbose", help="Verbose output logging", action='store_true')
 
         return parser.parse_args()

--- a/bin/ntlink_patch_gaps.py
+++ b/bin/ntlink_patch_gaps.py
@@ -707,6 +707,7 @@ def main() -> None:
     parser.add_argument("--soft_mask", help="If specified, will soft mask the filled gap", action="store_true")
     parser.add_argument("--verbose", help="Verbose logging - print out trimmed scaffolds without gaps",
                         action="store_true")
+    parser.add_argument("-v", "--version", action='version', version='ntLink v1.2.0')
     args = parser.parse_args()
 
     print_parameters(args)

--- a/bin/ntlink_stitch_paths.py
+++ b/bin/ntlink_stitch_paths.py
@@ -460,7 +460,7 @@ class NtLinkPath:
         parser.add_argument("--transitive", help="Require transitive support for edges?", action="store_true")
         parser.add_argument("--conservative", help="Conservative mode - take optimal N50 paths, no stitching",
                             action="store_true")
-        parser.add_argument("-v", "--version", action='version', version='ntLink v1.1.3')
+        parser.add_argument("-v", "--version", action='version', version='ntLink v1.2.0')
 
         return parser.parse_args()
 

--- a/ntLink
+++ b/ntLink
@@ -155,7 +155,7 @@ ifeq ($(target), None)
 endif
 
 version:
-	@echo "ntLink v1.1.3"
+	@echo "ntLink v1.2.0"
 	@echo "Written by Lauren Coombe (lcoombe@bcgsc.ca)"
 
 

--- a/ntLink
+++ b/ntLink
@@ -203,7 +203,7 @@ $(target).k$(small_k).w$(small_w).tsv: $(target)
 
 $(prefix).trimmed_scafs.fa: $(prefix).stitch.path $(prefix).n$(n).scaffold.dot $(target)
 	$(ntLink_time) sh -c '$(ntlink_path)/bin/ntlink_filter_sequences.py --fasta $(target) \
-	--dot $(prefix).n$(n).scaffold.dot --path $< -k $(small_k) -f $g |\
+	--dot $(prefix).n$(n).scaffold.dot --path $< -k $(small_k) -g $g |\
 	$(ntlink_path)/src/indexlr --long --pos -k $(small_k) -w $(small_w) -t $(t) - |\
 	$(ntlink_path)/bin/ntlink_overlap_sequences.py -m -  --path $< \
 	-s $(target) -d $(prefix).n$(n).scaffold.dot -p $(prefix) -g $(g) -k $(small_k) --outgap $(merge_gap) --trim_info'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ntLink",
-    version="1.1.3",
+    version="1.2.0",
     author="Lauren Coombe",
     author_email="lcoombe@bcgsc.ca",
     description="Genome assembly scaffolder using long reads",


### PR DESCRIPTION
* Prepare for release v1.2.0
* Bugfix for `-g` parameter of `ntlink_filter_sequences.py` in `ntLink`