### PR TITLE
Verbose mapping fix

### DIFF
--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -239,9 +239,11 @@ def get_accepted_anchor_contigs(mx_list, read_length, scaffolds, list_mx_info, a
             for j in range(contigs_hits[ctg].index + 1, i):
                 contigs_hits[contig_runs[j][0]].subsumed = True
             contigs_hits[ctg].hits.extend(list_hits)
+            contigs_hits[ctg].hit_count += len(list_hits)
         else:
             contigs_hits[ctg] = ntlink_pair.ContigRun(ctg, i, cnt)
             contigs_hits[ctg].hits.extend(list_hits)
+            contigs_hits[ctg].hit_count += len(list_hits)
 
     return_contigs_hits = {ctg: contigs_hits[ctg] for ctg in contigs_hits if not contigs_hits[ctg].subsumed}
 

--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -239,11 +239,10 @@ def get_accepted_anchor_contigs(mx_list, read_length, scaffolds, list_mx_info, a
             for j in range(contigs_hits[ctg].index + 1, i):
                 contigs_hits[contig_runs[j][0]].subsumed = True
             contigs_hits[ctg].hits.extend(list_hits)
-            contigs_hits[ctg].hit_count += len(list_hits)
+            contigs_hits[ctg].hit_count += cnt 
         else:
             contigs_hits[ctg] = ntlink_pair.ContigRun(ctg, i, cnt)
             contigs_hits[ctg].hits.extend(list_hits)
-            contigs_hits[ctg].hit_count += len(list_hits)
 
     return_contigs_hits = {ctg: contigs_hits[ctg] for ctg in contigs_hits if not contigs_hits[ctg].subsumed}
 


### PR DESCRIPTION
* Fix bug where the minimizer hit count was not updated for a contig when a subsumed contig was detected and removed
* Resulted in erroneously low minimizer hit count for a read mapping to a contig
  * The list of minimizers per mapping was not impacted