### PR TITLE
Deterministic fix

### DIFF
--- a/bin/ntlink_stitch_paths.py
+++ b/bin/ntlink_stitch_paths.py
@@ -396,6 +396,8 @@ class NtLinkPath:
     def print_paths(paths, out_filename, scaf_num):
         "Print the contig paths"
         path_id = 0 if scaf_num is None else scaf_num + 1
+        gap_re = re.compile(r'\d+N')
+        path_lists = []
         with open(out_filename, 'w') as fout:
             for path in paths:
                 path_list = []
@@ -405,9 +407,16 @@ class NtLinkPath:
                         path_list.append(node.get_gap())
                 if len(path_list) < 2:
                     continue
-                path_str = " ".join(path_list)
-                fout.write("ntLink_{path_id}\t{path}\n".format(path_id=path_id, path=path_str))
-                path_id += 1
+                path_list = ntlink_utils.normalize_path(path_list, gap_re)
+                path_lists.append(path_list)
+
+        # Sort to ensure deterministic ntLink rounds
+        path_lists = sorted(path_lists, key=lambda x: (x.get_ori_contig(), x.get_gap()))
+
+        for path_list in path_lists:
+            path_str = " ".join(path_list)
+            fout.write("ntLink_{path_id}\t{path}\n".format(path_id=path_id, path=path_str))
+            path_id += 1
 
 
     def main(self):

--- a/bin/ntlink_stitch_paths.py
+++ b/bin/ntlink_stitch_paths.py
@@ -398,25 +398,25 @@ class NtLinkPath:
         path_id = 0 if scaf_num is None else scaf_num + 1
         gap_re = re.compile(r'\d+N')
         path_lists = []
-        with open(out_filename, 'w') as fout:
-            for path in paths:
-                path_list = []
-                for node in path:
-                    path_list.append(node.get_ori_contig())
-                    if node.get_gap() is not None:
-                        path_list.append(node.get_gap())
-                if len(path_list) < 2:
-                    continue
-                path_list = ntlink_utils.normalize_path(path_list, gap_re)
-                path_lists.append(path_list)
+        for path in paths:
+            path_list = []
+            for node in path:
+                path_list.append(node.get_ori_contig())
+                if node.get_gap() is not None:
+                    path_list.append(node.get_gap())
+            if len(path_list) < 2:
+                continue
+            path_list = ntlink_utils.normalize_path(path_list, gap_re)
+            path_lists.append(path_list)
 
         # Sort to ensure deterministic ntLink rounds
-        path_lists = sorted(path_lists, key=lambda x: (x.get_ori_contig(), x.get_gap()))
+        path_lists = sorted(path_lists, key=lambda x: (len(x), x[0]), reverse=True)
 
-        for path_list in path_lists:
-            path_str = " ".join(path_list)
-            fout.write("ntLink_{path_id}\t{path}\n".format(path_id=path_id, path=path_str))
-            path_id += 1
+        with open(out_filename, 'w') as fout:
+            for path_list in path_lists:
+                    path_str = " ".join(path_list)
+                    fout.write("ntLink_{path_id}\t{path}\n".format(path_id=path_id, path=path_str))
+                    path_id += 1
 
 
     def main(self):


### PR DESCRIPTION
* We found that while ntLink was deterministic for a single run, if additional rounds of ntLink were performed, the results were not always fully deterministic
* Made a quick fix to sort/normalize the output paths to ensure that running rounds of ntLink is also determinstic
