### PR TITLE
Update soft-links created in ntLink to make consistent output file names

### DIFF
--- a/ntLink
+++ b/ntLink
@@ -229,3 +229,5 @@ $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.gap_fill.fa: $(target) $(prefix).n$
 	$(ntLink_time) $(ntlink_path)/bin/ntlink_patch_gaps.py --path $(prefix).trimmed_scafs.path \
 	 --mappings $(prefix).verbose_mapping.tsv -s $< --reads $(reads) -o $@ --large_k $(k) --min_gap 1 \
 	 --trims $(prefix).trimmed_scafs.tsv -k $(gap_k) -w $(gap_w)
+	ln -sf $@ $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.fa
+	echo "Done ntLink! Final post-ntLink and gap-filled scaffolds can be found in: $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.fa"

--- a/ntLink_rounds
+++ b/ntLink_rounds
@@ -77,12 +77,13 @@ run_rounds_gaps: check_prefix $(target).k$k.w$w.z$z.ntLink.gap_fill.fa \
 	$(target).k$k.w$w.z$z.ntLink.gap_fill.$(rounds)rounds.fa
 
 $(target).k$k.w$w.z$z.ntLink.$(rounds)rounds.fa: $(run_targets)
-	ln -s $(lastword $^) $@
+	ln -sf $(lastword $^) $@
 	echo "Done ntLink rounds!  Final scaffolds found in $@"
 
 $(target).k$k.w$w.z$z.ntLink.gap_fill.$(rounds)rounds.fa: $(run_targets_gaps)
-	ln -s $(lastword $^) $@
-	echo "Done ntLink rounds!  Final scaffolds found in $@"
+	ln -sf $(lastword $^) $@
+	ln -sf $@ $(target).k$k.w$w.z$z.ntLink.$(rounds)rounds.fa
+	echo "Done ntLink rounds!  Final scaffolds found in $(target).k$k.w$w.z$z.ntLink.$(rounds)rounds.fa"
 
 # Check prefix - must be the default for running ntLink rounds
 check_prefix:


### PR DESCRIPTION
* Make new soft-links to make ntLink output files the same name whether gap-filling is enabled or not
  * Makes the file naming structure used less applicable for the user