### PR TITLE
File cleaning

### DIFF
--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -494,6 +494,7 @@ class NtLink():
                                        "Set to 0 to allow mapping block to be up to read length",
                             type=float, default=0)
         parser.add_argument("-c", "--checkpoint", help="Mappings checkpoint file", required=False)
+        parser.add_argument("--pairs", help="Output pairs TSV file", action="store_true")
         parser.add_argument("-v", "--version", action='version', version='ntLink v1.3.2')
         parser.add_argument("--verbose", help="Verbose output logging", action='store_true')
 
@@ -547,7 +548,8 @@ class NtLink():
 
         pairs = self.filter_weak_anchor_pairs(pairs)
 
-        self.write_pairs(pairs)
+        if self.args.pairs:
+            self.write_pairs(pairs)
 
         # Build directed graph
         graph = self.build_scaffold_graph(pairs)

--- a/ntLink
+++ b/ntLink
@@ -168,7 +168,7 @@ version:
 	@echo "Written by Lauren Coombe (lcoombe@bcgsc.ca)"
 
 
-.PHONY: help scaffold version check_params clean pair gap_fill check_install
+.PHONY: help scaffold version check_params clean pair gap_fill check_install extra_clean
 .DELETE_ON_ERROR:
 .SECONDARY:
 
@@ -244,3 +244,9 @@ endif
 ifeq ($(shell test -e $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.gap_fill.fa && echo $$?),0)
 	rm -f $(target).k$(k).w$(w).z$(z).stitch.abyss-scaffold.fa
 endif
+
+extra_clean:
+ifeq ($(overlap), True)
+	rm -f $(prefix).trimmed_scafs.path
+endif
+	rm -f $(prefix).n1.scaffold.dot

--- a/ntLink
+++ b/ntLink
@@ -64,6 +64,9 @@ small_w=5
 gap_k=20
 gap_w=10
 
+# debugging parameters
+ntlink_pairs_tsv=False
+
 SHELL=bash -e -o pipefail
 ifeq ($(shell zsh -e -o pipefail -c 'true' 2>/dev/null; echo $$?), 0)
 # Set pipefail to ensure that all commands of a pipe succeed.
@@ -175,18 +178,19 @@ version:
 %.fa.gz: %.fa
 	$(ntLink_time) $(gzip) $<
 
-$(prefix).n$(n).scaffold.dot: $(target).k$(k).w$(w).tsv $(reads)
+ntlink_pair_params=
 ifeq ($(verbose), True)
-	$(ntLink_time)  sh -c '$(gzip) -cd $(reads) | \
-	indexlr --long --pos --strand -k $(k) -w $(w) -t $(t) - | \
-	$(ntlink_path)/bin/ntlink_pair.py -p $(prefix) -n $(n) -m $< -s $(target)  \
-	-k $(k) -a $(a) -z $(z) -f $(f) -x $(x) --verbose -'
-else
-	$(ntLink_time)  sh -c '$(gzip) -cd $(reads) | \
-	indexlr --long --pos --strand -k $(k) -w $(w) -t $(t) - | \
-	$(ntlink_path)/bin/ntlink_pair.py -p $(prefix) -n $(n) -m $< -s $(target)  \
-	-k $(k) -a $(a) -z $(z) -f $(f) -x $(x) -'
+ntlink_pair_params+=--verbose
 endif
+ifeq ($(ntlink_pairs_tsv), True)
+ntlink_pair_params+=--pairs
+endif
+
+$(prefix).n$(n).scaffold.dot: $(target).k$(k).w$(w).tsv $(reads)
+	$(ntLink_time)  sh -c '$(gzip) -cd $(reads) | \
+	indexlr --long --pos --strand -k $(k) -w $(w) -t $(t) - | \
+	$(ntlink_path)/bin/ntlink_pair.py -p $(prefix) -n $(n) -m $< -s $(target)  \
+	-k $(k) -a $(a) -z $(z) -f $(f) -x $(x) $(ntlink_pair_params) -'
 
 # Run abyss-scaffold scaffolding layout
 $(prefix).n%.abyss-scaffold.path: $(prefix).n$(n).scaffold.dot
@@ -222,8 +226,6 @@ $(target).k$(k).w$(w).z$(z).stitch.abyss-scaffold.fa: $(target) $(prefix).stitch
 	$(ntLink_time) MergeContigs -k2 $< $(prefix).stitch.path > $@
 endif
 
-clean: abyss_scaffold
-	rm -f $(prefix).n*.abyss-scaffold.path $(prefix).n*.abyss-scaffold.path.sterr
 
 $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.gap_fill.fa: $(target) $(prefix).n$(n).scaffold.dot $(prefix).trimmed_scafs.fa
 	$(ntLink_time) $(ntlink_path)/bin/ntlink_patch_gaps.py --path $(prefix).trimmed_scafs.path \
@@ -231,3 +233,14 @@ $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.gap_fill.fa: $(target) $(prefix).n$
 	 --trims $(prefix).trimmed_scafs.tsv -k $(gap_k) -w $(gap_w)
 	ln -sf $@ $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.fa
 	echo "Done ntLink! Final post-ntLink and gap-filled scaffolds can be found in: $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.fa"
+
+clean:
+	rm -f $(target).k$(k).w$(w).tsv
+ifeq ($(overlap), True)
+	rm -f $(prefix).trimmed_scafs.fa
+	rm -f $(prefix).trimmed_scafs.tsv
+	rm -f $(prefix).stitch.path
+endif
+ifeq ($(shell test -e $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.gap_fill.fa && echo $$?),0)
+	rm -f $(target).k$(k).w$(w).z$(z).stitch.abyss-scaffold.fa
+endif

--- a/ntLink_rounds
+++ b/ntLink_rounds
@@ -42,7 +42,7 @@ PYTHONPATH=$(ntlink_path)/src/btllib/install/lib/btllib/python
 
 .SECONDARY:
 .DELETE_ON_ERROR:
-.PHONY: run_rounds run_rounds_gaps check_prefix
+.PHONY: run_rounds run_rounds_gaps check_prefix clean
 
 help:
 	@echo ""
@@ -94,6 +94,7 @@ endif
 # First round of ntLink - with gap-filling
 $(target).k$k.w$w.z$z.ntLink.gap_fill.fa: $(target) $(reads)
 	$(ntLink_time) ntLink scaffold gap_fill target=$< reads=$(reads) k=$k w=$w z=$z
+	ntLink clean extra_clean target=$< reads=$(reads) k=$k w=$w z=$z
 	ln -sf $(target).k$k.w$w.z$z.ntLink.scaffolds.gap_fill.fa $(target).k$k.w$w.z$z.ntLink.gap_fill.fa
 	ln -sf $(target).k$k.w$w.z$z.ntLink.scaffolds.gap_fill.fa.agp $(target).k$k.w$w.z$z.ntLink.gap_fill.fa.agp
 	ln -sf $(target).k$k.w$w.z$z.verbose_mapping.tsv $(target).k$k.w$w.z$z.ntLink.gap_fill.fa.verbose_mapping.tsv
@@ -101,6 +102,7 @@ $(target).k$k.w$w.z$z.ntLink.gap_fill.fa: $(target) $(reads)
 # First round of ntLink - no gap-filling
 $(target).k$k.w$w.z$z.ntLink.fa: $(target) $(reads)
 	$(ntLink_time) ntLink scaffold target=$< reads=$(reads) k=$k w=$w z=$z
+	ntLink clean extra_clean target=$< reads=$(reads) k=$k w=$w z=$z
 	ln -sf $(target).k$k.w$w.z$z.ntLink.scaffolds.fa $(target).k$k.w$w.z$z.ntLink.fa
 	ln -sf $(target).k$k.w$w.z$z.trimmed_scafs.agp $(target).k$k.w$w.z$z.ntLink.fa.agp
 	ln -sf $(target).k$k.w$w.z$z.verbose_mapping.tsv $(target).k$k.w$w.z$z.ntLink.fa.verbose_mapping.tsv
@@ -113,6 +115,7 @@ $(target).k$k.w$w.z$z.ntLink.fa: $(target) $(reads)
 # Subsequent rounds of ntLink - gap-filling
 %.ntLink.gap_fill.fa:  %.gap_fill.fa $(reads) %.gap_fill.fa.k$k.w$w.z$z.verbose_mapping.tsv
 	$(ntLink_time) ntLink scaffold gap_fill target=$< reads=$(reads) k=$k w=$w z=$z
+	ntLink clean extra_clean target=$< reads=$(reads) k=$k w=$w z=$z
 	ln -sf $*.gap_fill.fa.k$k.w$w.z$z.ntLink.scaffolds.gap_fill.fa $@
 	ln -sf $*.gap_fill.fa.k$k.w$w.z$z.ntLink.scaffolds.gap_fill.fa.agp $*.ntLink.gap_fill.fa.agp
 	ln -sf $*.gap_fill.fa.k$k.w$w.z$z.verbose_mapping.tsv $*.ntLink.gap_fill.fa.verbose_mapping.tsv
@@ -120,6 +123,11 @@ $(target).k$k.w$w.z$z.ntLink.fa: $(target) $(reads)
 # Subsequent rounds of ntLink - no gap-filling
 %.ntLink.fa:  %.fa $(reads) %.fa.k$k.w$w.z$z.verbose_mapping.tsv
 	$(ntLink_time) ntLink scaffold target=$< reads=$(reads) k=$k w=$w z=$z
+	ntLink clean extra_clean target=$< reads=$(reads) k=$k w=$w z=$z
 	ln -sf $*.fa.k$k.w$w.z$z.ntLink.scaffolds.fa $@
 	ln -sf $*.fa.k$k.w$w.z$z.trimmed_scafs.agp $*.ntLink.fa.agp
 	ln -sf $*.fa.k$k.w$w.z$z.verbose_mapping.tsv $*.ntLink.fa.verbose_mapping.tsv
+
+# Clean up files
+clean:
+	rm -f $(prefix).*verbose_mapping.tsv


### PR DESCRIPTION
* Add rules to makefiles to facilitate clean-up of intermediate files
* Style improvements to `ntLink`
* Don't write out the pair TSV intermediate file by default