### PR TITLE
Add option for sensitive ntLink mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ z			Minimum size of contig (bp) to scaffold [1000]
 v                       If 1, track time and memory for each step of the pipeline [0]
 conservative		If False, runs ntLink in stitching mode [True]
 overlap			If True, runs extra step to attempt to identify and trim overlapping joined sequences [True]
+sensitive	        If True, runs mapping in sensitive mode [False]
 
 Note: 
 	- Ensure all assembly and read files are in the current working directory, making soft links if necessary

--- a/bin/ntlink_liftover_mappings.py
+++ b/bin/ntlink_liftover_mappings.py
@@ -88,8 +88,8 @@ def print_adjusted_mappings(read_id: str, mappings: list, outfile: io.TextIOWrap
     for i, ctg_run in enumerate(contig_runs):
         ctg, list_mappings = ctg_run
         if ctg not in contig_hits:
-            contig_hits[ctg] = ContigRun(ctg, i, len(list_mappings))
-            contig_hits[ctg].hits = list_mappings
+            contig_hits[ctg] = ContigRun(ctg, list_mappings)
+            contig_hits[ctg].index = i
         else:
             for j in range(contig_hits[ctg].index + 1, i):
                 contig_hits[contig_runs[j][0]].subsumed = True

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -346,7 +346,7 @@ class NtLink():
                         mx_pos_split_tups = line[1].split(" ")
                         mx_pos_split = []
                         mx_seen = set()
-                        mx_dup = set()
+                        mx_dups = set()
 
                         for mx_pos in mx_pos_split_tups:
                             mx, pos, strand = mx_pos.split(":")

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -496,6 +496,7 @@ class NtLink():
                             type=float, default=0)
         parser.add_argument("-c", "--checkpoint", help="Mappings checkpoint file", required=False)
         parser.add_argument("--pairs", help="Output pairs TSV file", action="store_true")
+        parser.add_argument("--sensitive", help="Run more sensitive read mapping", action="store_true")
         parser.add_argument("-v", "--version", action='version', version='ntLink v1.3.4')
         parser.add_argument("--verbose", help="Verbose output logging", action='store_true')
 

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -517,6 +517,8 @@ class NtLink():
         print("\t-x ", self.args.x)
         if self.args.checkpoint:
             print("\t-c ", self.args.checkpoint)
+        if self.args.sensitive:
+            print("\t--sensitive")
 
     def main(self):
         "Run ntLink graph stage"

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -77,11 +77,11 @@ class PairInfo:
 
 class ContigRun:
     "Represents information about a contig run based on a long read"
-    def __init__(self, contig, index, hit_count):
+    def __init__(self, contig, list_hits):
         self.contig = contig
-        self.index = index
-        self.hit_count = hit_count
-        self.hits = []
+        self.index = None
+        self.hit_count = len(list_hits)
+        self.hits = list_hits
         self._subsumed = False
         self.first_mx = None
         self.terminal_mx = None
@@ -433,8 +433,8 @@ class NtLink():
         read_mapping_positions = []
         for i, m in enumerate(mappings):
             contig_runs.append(m.contig_id)
-            accepted_anchor_contigs[m.contig_id] = ContigRun(m.contig_id, i, int(m.num_hits))
-            accepted_anchor_contigs[m.contig_id].hits = ntlink_utils.parse_minimizers(m.list_hits)
+            accepted_anchor_contigs[m.contig_id] = ContigRun(m.contig_id, ntlink_utils.parse_minimizers(m.list_hits))
+            accepted_anchor_contigs[m.contig_id].index = i
             # Generate random 64-bit integer to represent the minimizer hash
             first_hash = random.getrandbits(64)
             last_hash = random.getrandbits(64)

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -365,9 +365,10 @@ class NtLink():
 
 
                         # Filter ordered minimizer list for accepted contigs, keep track of hashes for gap sizes
+                        mx_accepted_pos = set([hit.read_pos for contig, contig_run in contig_runs.items() for hit in contig_run.hits])
                         mx_pos_split = [mx_tup for mx_tup in mx_pos_split
                                         if NtLink.list_mx_info[mx_tup[0]].contig in
-                                        accepted_anchor_contigs]
+                                        accepted_anchor_contigs and mx_tup[1] in mx_accepted_pos]
                         for mx, pos, strand in mx_pos_split:
                             mx_contig = NtLink.list_mx_info[mx].contig
                             if accepted_anchor_contigs[mx_contig].first_mx is None:

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -376,7 +376,8 @@ class NtLink():
 
 
                         # Filter ordered minimizer list for accepted contigs, keep track of hashes for gap sizes
-                        mx_accepted_pos = set([hit.read_pos for contig, contig_run in accepted_anchor_contigs.items() for hit in contig_run.hits])
+                        mx_accepted_pos = set([hit.read_pos for contig, contig_run in accepted_anchor_contigs.items()
+                                               for hit in contig_run.hits])
                         mx_pos_split = [mx_tup for mx_tup in mx_pos_split
                                         if NtLink.list_mx_info[mx_tup[0]].contig in
                                         accepted_anchor_contigs and int(mx_tup[1]) in mx_accepted_pos]
@@ -508,7 +509,8 @@ class NtLink():
         parser.add_argument("-c", "--checkpoint", help="Mappings checkpoint file", required=False)
         parser.add_argument("--pairs", help="Output pairs TSV file", action="store_true")
         parser.add_argument("--sensitive", help="Run more sensitive read mapping", action="store_true")
-        parser.add_argument("--repeat-filter", help="Remove repetitive minimizers within a long read's sketch", action="store_true")
+        parser.add_argument("--repeat-filter", help="Remove repetitive minimizers within a long read's sketch",
+                            action="store_true")
         parser.add_argument("-v", "--version", action='version', version='ntLink v1.3.4')
         parser.add_argument("--verbose", help="Verbose output logging", action='store_true')
 

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -365,10 +365,10 @@ class NtLink():
 
 
                         # Filter ordered minimizer list for accepted contigs, keep track of hashes for gap sizes
-                        mx_accepted_pos = set([hit.read_pos for contig, contig_run in contig_runs.items() for hit in contig_run.hits])
+                        mx_accepted_pos = set([hit.read_pos for contig, contig_run in accepted_anchor_contigs.items() for hit in contig_run.hits])
                         mx_pos_split = [mx_tup for mx_tup in mx_pos_split
                                         if NtLink.list_mx_info[mx_tup[0]].contig in
-                                        accepted_anchor_contigs and mx_tup[1] in mx_accepted_pos]
+                                        accepted_anchor_contigs and int(mx_tup[1]) in mx_accepted_pos]
                         for mx, pos, strand in mx_pos_split:
                             mx_contig = NtLink.list_mx_info[mx].contig
                             if accepted_anchor_contigs[mx_contig].first_mx is None:

--- a/bin/ntlink_pair.py
+++ b/bin/ntlink_pair.py
@@ -345,10 +345,21 @@ class NtLink():
                     if len(line) > 1:
                         mx_pos_split_tups = line[1].split(" ")
                         mx_pos_split = []
+                        mx_seen = set()
+                        mx_dup = set()
+
                         for mx_pos in mx_pos_split_tups:
                             mx, pos, strand = mx_pos.split(":")
                             if mx in target_mxs:
                                 mx_pos_split.append((mx, pos, strand))
+                                if self.args.repeat_filter:
+                                    if mx in mx_seen:
+                                        mx_dups.add(mx)
+                                    else:
+                                        mx_seen.add(mx)
+                        if self.args.repeat_filter:
+                            mx_pos_split = [(mx, pos, strand) for mx, pos, strand in mx_pos_split if mx not in mx_dups]
+
                         if not mx_pos_split:
                             continue
                         length_long_read = int(mx_pos_split[-1][1])
@@ -497,6 +508,7 @@ class NtLink():
         parser.add_argument("-c", "--checkpoint", help="Mappings checkpoint file", required=False)
         parser.add_argument("--pairs", help="Output pairs TSV file", action="store_true")
         parser.add_argument("--sensitive", help="Run more sensitive read mapping", action="store_true")
+        parser.add_argument("--repeat-filter", help="Remove repetitive minimizers within a long read's sketch", action="store_true")
         parser.add_argument("-v", "--version", action='version', version='ntLink v1.3.4')
         parser.add_argument("--verbose", help="Verbose output logging", action='store_true')
 
@@ -519,6 +531,8 @@ class NtLink():
             print("\t-c ", self.args.checkpoint)
         if self.args.sensitive:
             print("\t--sensitive")
+        if self.args.repeat_filter:
+            print("\t--repeat-filter")
 
     def main(self):
         "Run ntLink graph stage"

--- a/bin/ntlink_patch_gaps.py
+++ b/bin/ntlink_patch_gaps.py
@@ -771,6 +771,7 @@ def main() -> None:
     parser.add_argument("--stringent", help="If specified, will only use lower k/w re-mapping for filling gaps,"
                                             " will not fall back on original anchors", action="store_true")
     parser.add_argument("--soft_mask", help="If specified, will soft mask the filled gap", action="store_true")
+    parser.add_argument("--sensitive", help="Run more sensitive read mapping", action="store_true")
     parser.add_argument("--verbose", help="Verbose logging - print out trimmed scaffolds without gaps",
                         action="store_true")
     parser.add_argument("-v", "--version", action='version', version='ntLink v1.3.4')

--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -18,6 +18,7 @@ from read_fasta import read_fasta
 
 Scaffold = namedtuple("Scaffold", ["id", "length"])
 MinimizerPositions = namedtuple("MinimizerPositions", ["ctg_pos", "ctg_strand", "read_pos", "read_strand"])
+ContigMinimizerPositions = namedtuple("ContigMinimizerPositions", ["contig", "mx_positions"])
 
 class HiddenPrints:
     "Adapted from: https://stackoverflow.com/questions/8391411/how-to-block-calls-to-print"
@@ -198,18 +199,19 @@ def find_valid_mx_region(scaf_noori, scaf_ori, scaffolds, overlap, args, source=
 
 def get_accepted_anchor_contigs(mx_list, read_length, scaffolds, list_mx_info, args):
     "Returns dictionary of contigs of appropriate length, mx hits, whether subsumed"
-    contig_list = []
-    contig_positions = {}  # contig -> [mx positions]
+    contig_list = [] # list of (contig, mx_positions)
+    contig_positions = {}  # contig -> [mx_positions]
     for mx, pos, strand in mx_list:
         contig = list_mx_info[mx].contig
         if scaffolds[contig].length >= args.z:
-            contig_list.append(contig)
+            contig_mxs = MinimizerPositions(ctg_pos=list_mx_info[mx].position,
+                                            ctg_strand=list_mx_info[mx].strand,
+                                            read_pos=int(pos),
+                                            read_strand=strand)
+            contig_list.append(ContigMinimizerPositions(contig, contig_mxs))
             if contig not in contig_positions:
                 contig_positions[contig] = []
-            contig_positions[contig].append(MinimizerPositions(ctg_pos=list_mx_info[mx].position,
-                                                            ctg_strand=list_mx_info[mx].strand,
-                                                               read_pos=int(pos),
-                                                               read_strand=strand))
+            contig_positions[contig].append(contig_mxs)
 
     # Filter out hits where mapped length on contig is greater than the read length
     noisy_contigs = set()
@@ -229,28 +231,41 @@ def get_accepted_anchor_contigs(mx_list, read_length, scaffolds, list_mx_info, a
                             (args.x * abs(end_positions.read_pos - start_positions.read_pos)) + args.k)
             if abs(end_positions.ctg_pos - start_positions.ctg_pos) > threshold:
                 noisy_contigs.add(contig)
-    contig_list = [contig for contig in contig_list if contig not in noisy_contigs]
+    contig_list = [contig_tup for contig_tup in contig_list if contig_tup.contig not in noisy_contigs]
 
-    contig_runs = [(ctg, len(list(hits)), list(hits)) for ctg, hits in itertools.groupby(contig_list)]
-    contigs_hits = {}
-    for i, run_tup in enumerate(contig_runs):
-        ctg, cnt, list_hits = run_tup
-        if ctg in contigs_hits:
-            for j in range(contigs_hits[ctg].index + 1, i):
-                contigs_hits[contig_runs[j][0]].subsumed = True
-            contigs_hits[ctg].hits.extend(list_hits)
-            contigs_hits[ctg].hit_count += cnt 
-        else:
-            contigs_hits[ctg] = ntlink_pair.ContigRun(ctg, i, cnt)
-            contigs_hits[ctg].hits.extend(list_hits)
+    contig_runs = [ntlink_pair.ContigRun(ctg, [hit.mx_positions for hit in hits])
+                   for ctg, hits in itertools.groupby(contig_list, key=lambda x:x.contig)]
 
-    return_contigs_hits = {ctg: contigs_hits[ctg] for ctg in contigs_hits if not contigs_hits[ctg].subsumed}
+    # tally positions of runs for each contig
+    contig_runs_idx = {}
+    for i, ctg_run in enumerate(contig_runs):
+        if ctg_run.contig not in contig_runs_idx:
+            contig_runs_idx[ctg_run.contig] = []
+        contig_runs_idx[ctg_run.contig].append(i)
 
-    return_contig_runs_tmp = [ctg for ctg, hits, list_hits in contig_runs if not contigs_hits[ctg].subsumed]
-    return_contig_runs = [ctg for ctg, hits in itertools.groupby(return_contig_runs_tmp)]
+    # Now, go back and mark subsumed contigs where applicable
+    for ctg in contig_runs_idx:
+        if len(contig_runs_idx[ctg]) < 2:
+            continue
+        for i, j in zip(contig_runs_idx[ctg], contig_runs_idx[ctg][1:]):
+            for idx in range(i+1, j):
+                contig_runs[idx].subsumed = True
 
-    for ctg in contigs_hits:
-        contigs_hits[ctg].hits = contig_positions[ctg]
+    # Filter the flagged subsumed contig runs
+    contig_runs = [cr for cr in contig_runs if not cr.subsumed]
+
+    # Group again by contig
+    contig_runs_final = []
+    for ctg, runs in itertools.groupby(contig_runs, key=lambda x: x.contig):
+        contig_runs_final.append(ntlink_pair.ContigRun(ctg, [hit for cr in runs for hit in cr.hits]))
+
+    return_contig_runs = [ctg_run.contig for ctg_run in contig_runs_final]
+    return_contigs_hits = {ctg_run.contig: ctg_run for ctg_run in contig_runs_final}
+    if len(return_contigs_hits) != len(return_contig_runs):
+        print(return_contigs_hits)
+        print(return_contig_runs)
+    assert len(return_contigs_hits) == len(return_contig_runs)
+    assert len(return_contigs_hits) == len(contig_runs_final)
 
     return return_contigs_hits, return_contig_runs
 

--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -279,13 +279,15 @@ def mark_subsumed_sensitive(contig_runs, contig_runs_idx):
 def mark_subsumed_specific(contig_runs, contig_runs_idx):
     "Iterate over the contig runs and mark contigs as subsumed if any runs are subsumed"
     subsumed_ctgs = set()
-    for ctg, indices in contig_runs_idx.items():
-        if len(indices) < 2:
-            continue
-        for i, j in zip(indices, indices[1:]):
-            for idx in range(i + 1, j):
-                contig_runs[idx].subsumed = True
-                subsumed_ctgs.add(contig_runs[idx].contig)
+    contigs_hits = {}
+    for i, run_tup in enumerate(contig_runs):
+        ctg, cnt, list_hits = run_tup
+        if ctg in contigs_hits:
+            for j in range(contigs_hits[ctg] + 1, i):
+                subsumed_ctgs.add(contig_runs[j][0])
+        else:
+            contigs_hits[ctg] = i
+
     for cr in contig_runs:
         if cr.contig in subsumed_ctgs:
             cr.subsumed = True

--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -281,10 +281,10 @@ def mark_subsumed_specific(contig_runs, contig_runs_idx):
     subsumed_ctgs = set()
     contigs_hits = {}
     for i, run_tup in enumerate(contig_runs):
-        ctg, cnt, list_hits = run_tup
+        ctg = run_tup.contig
         if ctg in contigs_hits:
-            for j in range(contigs_hits[ctg] + 1, i):
-                subsumed_ctgs.add(contig_runs[j][0])
+            for j in range(contigs_hits[run_tup.contig] + 1, i):
+                subsumed_ctgs.add(contig_runs[j].contig)
         else:
             contigs_hits[ctg] = i
 

--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -9,8 +9,8 @@ from collections import namedtuple, defaultdict
 import os
 import re
 import sys
-import igraph as ig
 import itertools
+import igraph as ig
 import numpy as np
 import ntlink_pair
 
@@ -215,8 +215,7 @@ def get_accepted_anchor_contigs(mx_list, read_length, scaffolds, list_mx_info, a
 
     # Filter out hits where mapped length on contig is greater than the read length
     noisy_contigs = set()
-    for contig in contig_positions:
-        positions = contig_positions[contig]
+    for contig, positions in contig_positions.items():
         if len(positions) < 2:
             continue
         ctg_positions = [position.ctg_pos for position in positions]
@@ -244,10 +243,10 @@ def get_accepted_anchor_contigs(mx_list, read_length, scaffolds, list_mx_info, a
         contig_runs_idx[ctg_run.contig].append(i)
 
     # Now, go back and mark subsumed contigs where applicable
-    for ctg in contig_runs_idx:
-        if len(contig_runs_idx[ctg]) < 2:
+    for ctg, indices in contig_runs_idx.items():
+        if len(indices) < 2:
             continue
-        for i, j in zip(contig_runs_idx[ctg], contig_runs_idx[ctg][1:]):
+        for i, j in zip(indices, indices[1:]):
             for idx in range(i+1, j):
                 contig_runs[idx].subsumed = True
 
@@ -279,4 +278,3 @@ def parse_minimizers(minimizer_positions: str) -> list:
         return_mxs.append(MinimizerPositions(ctg_pos=int(ctg_pos), ctg_strand=ctg_strand,
                                              read_pos=int(read_pos), read_strand=read_strand))
     return return_mxs
-

--- a/bin/ntlink_utils.py
+++ b/bin/ntlink_utils.py
@@ -246,7 +246,7 @@ def get_accepted_anchor_contigs(mx_list, read_length, scaffolds, list_mx_info, a
     if args.sensitive:
         mark_subsumed_sensitive(contig_runs, contig_runs_idx)
     else:
-        mark_subsumed_conservative(contig_runs, contig_runs_idx)
+        mark_subsumed_specific(contig_runs, contig_runs_idx)
 
     # Filter the flagged subsumed contig runs
     contig_runs = [cr for cr in contig_runs if not cr.subsumed]
@@ -276,7 +276,7 @@ def mark_subsumed_sensitive(contig_runs, contig_runs_idx):
             for idx in range(i + 1, j):
                 contig_runs[idx].subsumed = True
 
-def mark_subsumed_conservative(contig_runs, contig_runs_idx):
+def mark_subsumed_specific(contig_runs, contig_runs_idx):
     "Iterate over the contig runs and mark contigs as subsumed if any runs are subsumed"
     subsumed_ctgs = set()
     for ctg, indices in contig_runs_idx.items():

--- a/ntLink
+++ b/ntLink
@@ -53,6 +53,9 @@ conservative=True
 # Run ntLink mapping in sensitive mode?
 sensitive=False
 
+# Use repeat filter?
+repeats=False
+
 # Output verbose read mappings to contigs?
 verbose=True
 
@@ -191,6 +194,9 @@ ntlink_pair_params+=--pairs
 endif
 ifeq ($(sensitive), True)
 ntlink_pair_params+=--sensitive
+endif
+ifeq ($(repeats), True)
+ntlink_pair_params+=--repeat-filter
 endif
 
 $(prefix).n$(n).scaffold.dot: $(target).k$(k).w$(w).tsv $(reads)

--- a/ntLink
+++ b/ntLink
@@ -50,6 +50,8 @@ x=0
 # Run ntLink in conservative mode?
 conservative=True
 
+# Run ntLink mapping in sensitive mode?
+
 # Output verbose read mappings to contigs?
 verbose=True
 
@@ -119,6 +121,7 @@ help:
 	@echo "v			If 1, track time and memory for each step of the pipeline [0]"
 	@echo "conservative		If False, runs ntLink in stitching mode [True]"
 	@echo "overlap			If True, runs extra step to attempt to identify and trim overlapping joined sequences [True]"
+	@echo "sensitive	        If True, runs mapping in sensitive mode [False]"
 	@echo ""
 	@echo "Note: "
 	@echo "	- Ensure all assembly and read files are in the current working directory, making soft links if necessary"
@@ -184,6 +187,9 @@ ntlink_pair_params+=--verbose
 endif
 ifeq ($(ntlink_pairs_tsv), True)
 ntlink_pair_params+=--pairs
+endif
+ifeq ($(sensitive), True)
+ntlink_pair_params+=--sensitive
 endif
 
 $(prefix).n$(n).scaffold.dot: $(target).k$(k).w$(w).tsv $(reads)

--- a/ntLink
+++ b/ntLink
@@ -51,6 +51,7 @@ x=0
 conservative=True
 
 # Run ntLink mapping in sensitive mode?
+sensitive=False
 
 # Output verbose read mappings to contigs?
 verbose=True


### PR DESCRIPTION
* Add option for `sensitive` mappings with ntLink
  * This option impacts how subsumed mappings are dealt with
* It's recommended to use the default `sensitive=False` when using ntLink in the typical case (scaffolding), but `sensitive=True` when using ntLink mappings for another application (ex. in GoldRush-Edit) 