### PR TITLE
Overlap memory fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate ntlink_CI
-      conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda python pylint pytest pandas abyss=2.3.1
+      conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda python=3.9 pylint pytest pandas abyss=2.3.1
       conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda --file requirements.txt
     displayName: Install Anaconda packages
   - script: |

--- a/bin/ntlink_filter_sequences.py
+++ b/bin/ntlink_filter_sequences.py
@@ -18,7 +18,7 @@ def filter_sequences(args, scaffolds, valid_mx_regions):
     "Filter the input fasta file to only output those in valid_mx_regions, in order from the path file"
     with open(args.path, 'r') as path_fin:
         for path in path_fin:
-            _, path_seq = path.strip().split("\t")
+            path_name, path_seq = path.strip().split("\t")
             path_seq = path_seq.split(" ")
             path_seq = ntlink_utils.normalize_path(path_seq, gap_re)
             for node in path_seq:
@@ -26,7 +26,9 @@ def filter_sequences(args, scaffolds, valid_mx_regions):
                     continue
                 node_name = node.strip("+-")
                 if node_name in valid_mx_regions:
-                    print(">{}\n{}".format(scaffolds[node_name].ctg_id, scaffolds[node_name].sequence))
+                    print(">{}\n{}".format(scaffolds[node_name].ctg_id,
+                                           scaffolds[node_name].sequence))
+            print(">LAST{}\nN".format(path_name))
 
 def read_fasta_file(filename, args):
     "Read a fasta file into memory. Returns dictionary of scafID -> Scaffold"

--- a/bin/ntlink_filter_sequences.py
+++ b/bin/ntlink_filter_sequences.py
@@ -7,16 +7,37 @@ Written by Lauren Coombe @lcoombe
 
 import argparse
 import re
-from read_fasta import read_fasta
+import btllib
+
 import ntlink_utils
 import ntlink_overlap_sequences
 
-def filter_sequences(fa_in, valid_mx_regions):
-    "Filter the input fasta file to only output those in valid_mx_regions"
-    with open(fa_in, 'r') as fin:
-        for name, seq, _, _ in read_fasta(fin):
-            if name in valid_mx_regions:
-                print(">{}\n{}".format(name, seq))
+gap_re = re.compile(r'^(\d+)N$')
+
+def filter_sequences(args, scaffolds, valid_mx_regions):
+    "Filter the input fasta file to only output those in valid_mx_regions, in order from the path file"
+    with open(args.path, 'r') as path_fin:
+        for path in path_fin:
+            _, path_seq = path.strip().split("\t")
+            path_seq = path_seq.split(" ")
+            path_seq = ntlink_utils.normalize_path(path_seq, gap_re)
+            for node in path_seq:
+                if re.search(gap_re, node):
+                    continue
+                node_name = node.strip("+-")
+                if node_name in valid_mx_regions:
+                    print(">{}\n{}".format(scaffolds[node_name].ctg_id, scaffolds[node_name].sequence))
+
+def read_fasta_file(filename, args):
+    "Read a fasta file into memory. Returns dictionary of scafID -> Scaffold"
+    scaffolds = {}
+
+    with btllib.SeqReader(filename, btllib.SeqReaderFlag.LONG_MODE, args.t) as reader:
+        for record in reader:
+            scaffolds[record.id] = ntlink_overlap_sequences.ScaffoldCut(ctg_id=record.id,
+                                                                        sequence=record.seq, store_seq=True)
+
+    return scaffolds
 
 def main():
     "Run filtering of input sequences, print to the command line"
@@ -27,18 +48,18 @@ def main():
     parser.add_argument("-k", help="K-mer size (bp)", required=True, type=int)
     parser.add_argument("-f", help="Fudge factor for estimated overlap [0.5]", type=float, default=0.5)
     parser.add_argument("-g", help="Minimum gap size (bp) [20]", required=False, type=int, default=20)
+    parser.add_argument("-t", help="Number of threads", default=8, type=int)
     parser.add_argument("-v", "--version", action='version', version='ntLink v1.3.4')
 
     args = parser.parse_args()
 
-    gap_re = re.compile(r'^(\d+)N$')
 
     with ntlink_utils.HiddenPrints():
         graph, _ = ntlink_utils.read_scaffold_graph(args.dot)
-        scaffolds = ntlink_overlap_sequences.read_fasta_file_trim_prep(args.fasta)
+        scaffolds = read_fasta_file(args.fasta, args)
         valid_mx_regions = ntlink_utils.find_valid_mx_regions(args, gap_re, graph, scaffolds)
 
-    filter_sequences(args.fasta, valid_mx_regions)
+    filter_sequences(args, scaffolds, valid_mx_regions)
 
 
 if __name__ == "__main__":

--- a/bin/ntlink_overlap_sequences.py
+++ b/bin/ntlink_overlap_sequences.py
@@ -544,7 +544,6 @@ def main():
     valid_mx_positions = ntlink_utils.find_valid_mx_regions(args, gap_re, graph, scaffolds)
 
     args.m = "/dev/stdin" if args.m == "-" else args.m
-    #mxs_info, mxs = read_minimizers(args.m, valid_mx_positions)
 
     new_paths = merge_overlapping_pathfile(args, gap_re, graph, scaffolds, valid_mx_positions)
 

--- a/bin/ntlink_overlap_sequences.py
+++ b/bin/ntlink_overlap_sequences.py
@@ -137,7 +137,7 @@ def read_minimizers(tsv_filename, valid_mx_positions):
 
     return mx_info, mxs
 
-def read_minimizers_path(mx_reader, valid_mx_positions, path_name):
+def read_minimizers_path(mx_reader, valid_mx_positions):
     "Read in the minimizers for the given path, stopping at the LAST marker"
     mx_info = defaultdict(dict)  # contig -> mx -> (contig, position)
     mxs = {}  # Contig -> [list of minimizers]
@@ -147,9 +147,11 @@ def read_minimizers_path(mx_reader, valid_mx_positions, path_name):
         if re.search(final_sequence_marker_re, name):
             return mx_info, mxs
         read_minimizer_line(line, mx_info, mxs, name, valid_mx_positions)
+    return mx_info, mxs
 
 
 def read_minimizer_line(line, mx_info, mxs, name, valid_mx_positions):
+    "Read a line from the indexlr minimizer file"
     if len(line) < 2 or name not in valid_mx_positions:
         return
     dup_mxs = set() # Set of minimizers identified as duplicates
@@ -409,8 +411,7 @@ def merge_overlapping_pathfile(args, gap_re, graph, scaffolds, valid_mx_position
                 path_id, path_seq = path.strip().split("\t")
                 path_seq = path_seq.split(" ")
                 path_seq = ntlink_utils.normalize_path(path_seq, gap_re)
-                mxs_info, mxs = read_minimizers_path(minimizers_reader, valid_mx_positions,
-                                                     path_id)
+                mxs_info, mxs = read_minimizers_path(minimizers_reader, valid_mx_positions)
                 for source, gap, target in zip(path_seq, path_seq[1:], path_seq[2:]):
                     gap_match = re.search(gap_re, gap)
                     if not gap_match:

--- a/bin/ntlink_overlap_sequences.py
+++ b/bin/ntlink_overlap_sequences.py
@@ -22,7 +22,7 @@ MappedPathInfo = namedtuple("MappedPathInfo",
 class ScaffoldCut:
     "Defines a scaffold, and the cut points for that scaffold"
 
-    def __init__(self, ctg_id, sequence):
+    def __init__(self, ctg_id, sequence, store_seq=False):
         self.ctg_id = ctg_id
         self.length = len(sequence)
         self._ori = None
@@ -30,6 +30,10 @@ class ScaffoldCut:
         self._source_cut_flag = False
         self._target_cut = None
         self._target_cut_flag = False
+        if store_seq:
+            self.sequence = sequence
+        else:
+            self.sequence = None
 
     @property
     def ori(self):

--- a/bin/ntlink_overlap_sequences.py
+++ b/bin/ntlink_overlap_sequences.py
@@ -132,8 +132,7 @@ def read_minimizers(tsv_filename, valid_mx_positions):
     with open(tsv_filename, 'r') as tsv:
         for line in tsv:
             line = line.strip().split("\t")
-            name = line[0]
-            read_minimizer_line(line, mx_info, mxs, name, valid_mx_positions)
+            read_minimizer_line(line, mx_info, mxs, valid_mx_positions)
 
     return mx_info, mxs
 
@@ -146,12 +145,13 @@ def read_minimizers_path(mx_reader, valid_mx_positions):
         name = line[0]
         if re.search(final_sequence_marker_re, name):
             return mx_info, mxs
-        read_minimizer_line(line, mx_info, mxs, name, valid_mx_positions)
+        read_minimizer_line(line, mx_info, mxs, valid_mx_positions)
     return mx_info, mxs
 
 
-def read_minimizer_line(line, mx_info, mxs, name, valid_mx_positions):
+def read_minimizer_line(line, mx_info, mxs, valid_mx_positions):
     "Read a line from the indexlr minimizer file"
+    name = line[0]
     if len(line) < 2 or name not in valid_mx_positions:
         return
     dup_mxs = set() # Set of minimizers identified as duplicates

--- a/bin/ntlink_overlap_sequences.py
+++ b/bin/ntlink_overlap_sequences.py
@@ -19,6 +19,8 @@ import ntlink_utils
 MappedPathInfo = namedtuple("MappedPathInfo",
                             ["mapped_region_length", "mid_mx", "median_length_from_end"])
 
+final_sequence_marker_re = re.compile(r'^LAST(ntLink_\d+)$')
+
 class ScaffoldCut:
     "Defines a scaffold, and the cut points for that scaffold"
 
@@ -129,27 +131,44 @@ def read_minimizers(tsv_filename, valid_mx_positions):
     mxs = {}  # Contig -> [list of minimizers]
     with open(tsv_filename, 'r') as tsv:
         for line in tsv:
-            dup_mxs = set()  # Set of minimizers identified as duplicates
             line = line.strip().split("\t")
-            if len(line) > 1:
-                name = line[0]
-                if name not in valid_mx_positions:
-                    continue
-                mx_pos_split = line[1].split(" ")
-                for mx_pos in mx_pos_split:
-                    mx, pos = mx_pos.split(":")
-                    if not is_in_valid_region(int(pos), valid_mx_positions[name]):
-                        continue
-                    if name in mx_info and mx in mx_info[name]:  # This is a duplicate
-                        dup_mxs.add(mx)
-                    else:
-                        mx_info[name][mx] = (name, int(pos))
-                mx_info[name] = {mx: mx_info[name][mx] for mx in mx_info[name] if mx not in dup_mxs}
-                mxs[name] = [[mx for mx, pos in (mx_pos.split(":") for mx_pos in mx_pos_split)
-                              if mx not in dup_mxs and mx in mx_info[name] and
-                              is_in_valid_region(int(pos), valid_mx_positions[name])]]
+            name = line[0]
+            read_minimizer_line(line, mx_info, mxs, name, valid_mx_positions)
 
     return mx_info, mxs
+
+def read_minimizers_path(mx_reader, valid_mx_positions, path_name):
+    "Read in the minimizers for the given path, stopping at the LAST marker"
+    mx_info = defaultdict(dict)  # contig -> mx -> (contig, position)
+    mxs = {}  # Contig -> [list of minimizers]
+    for line in mx_reader:
+        line = line.strip().split("\t")
+        name = line[0]
+        if re.search(final_sequence_marker_re, name):
+            return mx_info, mxs
+        read_minimizer_line(line, mx_info, mxs, name, valid_mx_positions)
+
+
+def read_minimizer_line(line, mx_info, mxs, name, valid_mx_positions):
+    if len(line) < 2 or name not in valid_mx_positions:
+        return
+    dup_mxs = set() # Set of minimizers identified as duplicates
+    mx_pos_split = line[1].split(" ")
+
+    for mx_pos in mx_pos_split:
+        mx, pos = mx_pos.split(":")
+        if not is_in_valid_region(int(pos), valid_mx_positions[name]):
+            continue
+        if name in mx_info and mx in mx_info[name]:  # This is a duplicate
+            dup_mxs.add(mx)
+        else:
+            mx_info[name][mx] = (name, int(pos))
+
+    mx_info[name] = {mx: mx_info[name][mx] for mx in mx_info[name] if mx not in dup_mxs}
+    mxs[name] = [[mx for mx, pos in (mx_pos.split(":") for mx_pos in mx_pos_split)
+                  if mx not in dup_mxs and mx in mx_info[name] and
+                  is_in_valid_region(int(pos), valid_mx_positions[name])]]
+
 
 def read_fasta_file_trim_prep(filename):
     "Read a fasta file into memory. Returns dictionary of scafID -> Scaffold"
@@ -377,33 +396,37 @@ def merge_overlapping(list_mxs, list_mx_info, source, target, scaffolds, args, g
 
     return True
 
-def merge_overlapping_pathfile(args, gap_re, graph, mxs, mxs_info, scaffolds):
+def merge_overlapping_pathfile(args, gap_re, graph, scaffolds, valid_mx_positions):
     "Read through pathfile, and merge overlapping pieces, updating path file"
     print(datetime.datetime.today(), ": Finding scaffold overlaps", file=sys.stdout)
     out_pathfile = open(args.p + ".trimmed_scafs.path", 'w')
     my_paths = {}
+
     with open(args.path, 'r') as path_fin:
-        for path in path_fin:
-            new_path = []
-            path_id, path_seq = path.strip().split("\t")
-            path_seq = path_seq.split(" ")
-            path_seq = ntlink_utils.normalize_path(path_seq, gap_re)
-            for source, gap, target in zip(path_seq, path_seq[1:], path_seq[2:]):
-                gap_match = re.search(gap_re, gap)
-                if not gap_match:
-                    continue
-                if int(gap_match.group(1)) <= args.g + 1 and \
-                        ntlink_utils.has_estimated_overlap(graph, source, target):
-                    cuts_found = merge_overlapping(mxs, mxs_info, source, target, scaffolds, args,
-                                      graph.es()[ntlink_utils.edge_index(graph, source, target)]["d"])
-                    if cuts_found:
-                        gap = "{}N".format(args.outgap)
-                if not new_path:
-                    new_path.append(source)
-                new_path.append(gap)
-                new_path.append(target)
-            out_pathfile.write("{path_id}\t{ctgs}\n".format(path_id=path_id, ctgs=" ".join(new_path)))
-            my_paths[path_id] = new_path
+        with open(args.m, 'r') as minimizers_reader:
+            for path in path_fin:
+                new_path = []
+                path_id, path_seq = path.strip().split("\t")
+                path_seq = path_seq.split(" ")
+                path_seq = ntlink_utils.normalize_path(path_seq, gap_re)
+                mxs_info, mxs = read_minimizers_path(minimizers_reader, valid_mx_positions,
+                                                     path_id)
+                for source, gap, target in zip(path_seq, path_seq[1:], path_seq[2:]):
+                    gap_match = re.search(gap_re, gap)
+                    if not gap_match:
+                        continue
+                    if int(gap_match.group(1)) <= args.g + 1 and \
+                            ntlink_utils.has_estimated_overlap(graph, source, target):
+                        cuts_found = merge_overlapping(mxs, mxs_info, source, target, scaffolds, args,
+                                          graph.es()[ntlink_utils.edge_index(graph, source, target)]["d"])
+                        if cuts_found:
+                            gap = "{}N".format(args.outgap)
+                    if not new_path:
+                        new_path.append(source)
+                    new_path.append(gap)
+                    new_path.append(target)
+                out_pathfile.write("{path_id}\t{ctgs}\n".format(path_id=path_id, ctgs=" ".join(new_path)))
+                my_paths[path_id] = new_path
     out_pathfile.close()
     return my_paths
 
@@ -520,9 +543,9 @@ def main():
     valid_mx_positions = ntlink_utils.find_valid_mx_regions(args, gap_re, graph, scaffolds)
 
     args.m = "/dev/stdin" if args.m == "-" else args.m
-    mxs_info, mxs = read_minimizers(args.m, valid_mx_positions)
+    #mxs_info, mxs = read_minimizers(args.m, valid_mx_positions)
 
-    new_paths = merge_overlapping_pathfile(args, gap_re, graph, mxs, mxs_info, scaffolds)
+    new_paths = merge_overlapping_pathfile(args, gap_re, graph, scaffolds, valid_mx_positions)
 
     if args.trim_info:
         print_trim_coordinates(args, scaffolds)

--- a/ntLink
+++ b/ntLink
@@ -225,7 +225,7 @@ $(target).k$(small_k).w$(small_w).tsv: $(target)
 
 $(prefix).trimmed_scafs.fa: $(prefix).stitch.path $(prefix).n$(n).scaffold.dot $(target)
 	$(ntLink_time) sh -c '$(ntlink_path)/bin/ntlink_filter_sequences.py --fasta $(target) \
-	--dot $(prefix).n$(n).scaffold.dot --path $< -k $(small_k) -g $g |\
+	--dot $(prefix).n$(n).scaffold.dot --path $< -k $(small_k) -g $g -t $t |\
 	indexlr --long --pos -k $(small_k) -w $(small_w) -t $(t) - |\
 	$(ntlink_path)/bin/ntlink_overlap_sequences.py -m -  --path $< \
 	-s $(target) -d $(prefix).n$(n).scaffold.dot -p $(prefix) -g $(g) -k $(small_k) --outgap $(merge_gap) --trim_info'


### PR DESCRIPTION
* Refactoring the overlap stage of ntLink to reduce the peak memory usage
  * In some cases, found that the memory was inflated due to storing all the minimizers in memory
  * To address this, refactored the code to only store the minimizers a path at a time