### PR TITLE
Flexible installation path for ntLink scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,9 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate ntlink_CI
-      conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda python pylint pytest pandas abyss=2.3.1
-      conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda --file requirements.txt
+      conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda python=3.9 mamba
+      mamba install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda pylint pytest pandas abyss
+      mamba install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda --file requirements.txt
     displayName: Install Anaconda packages
   - script: |
       source activate ntlink_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,8 @@ jobs:
   - script: |
       source activate ntlink_CI
       conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda python=3.9 mamba
-      mamba install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda pylint pytest pandas abyss
-      mamba install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda --file requirements.txt
+      mamba install --yes --quiet -c conda-forge -c bioconda pylint pytest pandas abyss
+      mamba install --yes --quiet -c conda-forge -c bioconda --file requirements.txt
     displayName: Install Anaconda packages
   - script: |
       source activate ntlink_CI
@@ -40,8 +40,9 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate ntlink_CI
-      conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda python=3.9 pylint pytest pandas abyss=2.3.1
-      conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda --file requirements.txt
+      conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda python=3.9 mamba
+      mamba install --yes --quiet -c conda-forge -c bioconda pylint pytest pandas abyss
+      mamba install --yes --quiet -c conda-forge -c bioconda --file requirements.txt
     displayName: Install Anaconda packages
   - script: |
       source activate ntlink_CI

--- a/ntLink
+++ b/ntLink
@@ -14,7 +14,7 @@ ntlink_path=$(shell dirname $(realpath $(MAKEFILE_LIST)))/bin
 # If the ntlink python files are detected already in the PATH,
 # assume setup.py has been used for installation, and adjust expected path
 ifneq ($(shell command -v ntlink_pair.py),)
-ntlink_path=$(shell dirname $(command -v ntlink_pair.py))
+ntlink_path=$(shell dirname $(shell command -v ntlink_pair.py))
 endif
 
 # Window size

--- a/ntLink
+++ b/ntLink
@@ -8,8 +8,14 @@
 target=None
 reads=None
 
-# Path to pairing code
-ntlink_path=$(shell dirname $(realpath $(MAKEFILE_LIST)))
+# Path to pairing code and other ntLink files
+ntlink_path=$(shell dirname $(realpath $(MAKEFILE_LIST)))/bin
+
+# If the ntlink python files are detected already in the PATH,
+# assume setup.py has been used for installation, and adjust expected path
+ifneq ($(shell command -v ntlink_pair.py),)
+ntlink_path=$(shell dirname $(command -v ntlink_pair.py))
+endif
 
 # Window size
 w=100
@@ -211,7 +217,7 @@ endif
 $(prefix).n$(n).scaffold.dot: $(target).k$(k).w$(w).tsv $(reads)
 	$(ntLink_time)  sh -c '$(gzip) -cd $(reads) | \
 	indexlr --long --pos --strand --len -k $(k) -w $(w) -t $(t) - | \
-	$(ntlink_path)/bin/ntlink_pair.py -p $(prefix) -n $(n) -m $< -s $(target)  \
+	$(ntlink_path)/ntlink_pair.py -p $(prefix) -n $(n) -m $< -s $(target)  \
 	-k $(k) -a $(a) -z $(z) -f $(f) -x $(x) $(ntlink_pair_params) -'
 
 # Run abyss-scaffold scaffolding layout
@@ -222,10 +228,10 @@ $(prefix).n%.abyss-scaffold.path: $(prefix).n$(n).scaffold.dot
 
 $(prefix).stitch.path: $(path_targets)
 ifeq ($(conservative), True)
-	$(ntLink_time) $(ntlink_path)/bin/ntlink_stitch_paths.py --min_n $(n) --max_n $(max_n)  -p out \
+	$(ntLink_time) $(ntlink_path)/ntlink_stitch_paths.py --min_n $(n) --max_n $(max_n)  -p out \
 	-g $(prefix).n$(n).scaffold.dot --conservative $^ -o $@
 else
-	$(ntLink_time) $(ntlink_path)/bin/ntlink_stitch_paths.py --min_n $(n) --max_n $(max_n)  -p out \
+	$(ntLink_time) $(ntlink_path)/ntlink_stitch_paths.py --min_n $(n) --max_n $(max_n)  -p out \
 	-g $(prefix).n$(n).scaffold.dot $^ -o $@
 endif
 	rm -f $(prefix).n*.abyss-scaffold.path $(prefix).n*.abyss-scaffold.path.sterr
@@ -234,10 +240,10 @@ $(target).k$(small_k).w$(small_w).tsv: $(target)
 	$(ntLink_time) indexlr --long --pos -k $(small_k) -w $(small_w) -t $(t) $< > $@
 
 $(prefix).trimmed_scafs.fa: $(prefix).stitch.path $(prefix).n$(n).scaffold.dot $(target)
-	$(ntLink_time) sh -c '$(ntlink_path)/bin/ntlink_filter_sequences.py --fasta $(target) \
+	$(ntLink_time) sh -c '$(ntlink_path)/ntlink_filter_sequences.py --fasta $(target) \
 	--dot $(prefix).n$(n).scaffold.dot --path $< -k $(small_k) -g $g -t $t |\
 	indexlr --long --pos -k $(small_k) -w $(small_w) -t $(t) - |\
-	$(ntlink_path)/bin/ntlink_overlap_sequences.py -m -  --path $< \
+	$(ntlink_path)/ntlink_overlap_sequences.py -m -  --path $< \
 	-s $(target) -d $(prefix).n$(n).scaffold.dot -p $(prefix) -g $(g) -k $(small_k) --outgap $(merge_gap) --trim_info'
 
 ifeq ($(overlap), True)
@@ -254,7 +260,7 @@ ifeq ($(soft_mask), True)
 endif
 
 $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.gap_fill.fa: $(target) $(prefix).n$(n).scaffold.dot $(prefix).trimmed_scafs.fa
-	$(ntLink_time) $(ntlink_path)/bin/ntlink_patch_gaps.py --path $(prefix).trimmed_scafs.path \
+	$(ntLink_time) $(ntlink_path)/ntlink_patch_gaps.py --path $(prefix).trimmed_scafs.path \
 	 --mappings $(prefix).verbose_mapping.tsv -s $< --reads $(reads) -o $@ --large_k $(k) --min_gap 1 \
 	 --trims $(prefix).trimmed_scafs.tsv -k $(gap_k) -w $(gap_w) $(gap_opts)
 	ln -sf $@ $(target).k$(k).w$(w).z$(z).ntLink.scaffolds.fa

--- a/ntLink_rounds
+++ b/ntLink_rounds
@@ -37,8 +37,16 @@ ntLink_time=command time -v -o $@.time
 endif
 endif
 
-# Path to pairing code
-ntlink_path=$(shell dirname $(realpath $(MAKEFILE_LIST)))
+
+# Path to pairing code and other ntLink files
+ntlink_path=$(shell dirname $(realpath $(MAKEFILE_LIST)))/bin
+
+# If the ntlink python files are detected already in the PATH,
+# assume setup.py has been used for installation, and adjust expected path
+ifneq ($(shell command -v ntlink_liftover_mappings.py),)
+ntlink_path=$(shell dirname $(command -v ntlink_liftover_mappings.py))
+endif
+
 
 .SECONDARY:
 .DELETE_ON_ERROR:
@@ -113,7 +121,7 @@ endif
 
 # Liftover
 %.fa.k$k.w$w.z$z.verbose_mapping.tsv: %.fa
-	$(ntLink_time) $(ntlink_path)/bin/ntlink_liftover_mappings.py -k $k \
+	$(ntLink_time) $(ntlink_path)/ntlink_liftover_mappings.py -k $k \
 	-a $*.fa.agp -m $*.fa.verbose_mapping.tsv -o $@
 
 # Subsequent rounds of ntLink - gap-filling

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setuptools.setup(
     scripts = ["bin/ntlink_pair.py", "bin/read_fasta.py", "bin/ntlink_utils.py",
                "bin/ntlink_filter_sequences.py", "bin/ntlink_liftover_mappings.py",
                "bin/ntlink_overlap_sequences.py", "bin/ntlink_patch_gaps.py",
-               "bin/ntlink_stitch_paths.py", "bin/ntjoin_utils.py"],
+               "bin/ntlink_stitch_paths.py", "bin/ntjoin_utils.py", "bin/ntlink_paf_output.py",
+		"bin/path_node.py", "ntLink", "ntLink_rounds"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/bcgsc/ntLink",
     license="GPLv3",
     python_requires=">=3",
-    install_requires=["python-igraph", "numpy"],
+    install_requires=["python-igraph", "numpy", "btllib"],
     scripts = ["bin/ntlink_pair.py", "bin/read_fasta.py", "bin/ntlink_utils.py",
                "bin/ntlink_filter_sequences.py", "bin/ntlink_liftover_mappings.py",
                "bin/ntlink_overlap_sequences.py", "bin/ntlink_patch_gaps.py",


### PR DESCRIPTION
* Add flexibility to where the ntLink scripts can be located relative to each other
* If the scripts are found in the same directory as the `ntLink` Makefile, then use this path. Otherwise, revert to the previous behaviour and look for the files in directories relative to the Makefile
  * The former behaviour would be relevant in the case that `setup.py` is used for installation