### PR TITLE
Fix macOS CI - install conda via miniforge

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,13 +34,20 @@ jobs:
   pool:
     vmImage: macOS-latest
   steps:
-  - script: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
   - script: conda create --yes --quiet --name ntlink_CI
     displayName: Create Anaconda environment
   - script: |
       source activate ntlink_CI
-      conda install --yes --quiet --name ntlink_CI -c conda-forge -c bioconda python=3.9 mamba
       mamba install --yes --quiet -c conda-forge -c bioconda pylint pytest pandas abyss
       mamba install --yes --quiet -c conda-forge -c bioconda --file requirements.txt
     displayName: Install Anaconda packages

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
 python-igraph
-btllib <= 1.4.10
+btllib


### PR DESCRIPTION
* Recently, macOS-latest VM was updated to use macOS-14
  * This VM no longer has conda installed by default
* Workaround is to install miniforge as part of the CI
  * This already has mamba, which is a side benefit
* Remove btllib version constraint from `requirements.txt`